### PR TITLE
refactor: use schema.graphql for supporting graphql-codegen

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "@cloudflare/workers-types": "^3.14.1",
     "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
     "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
+    "@graphql-tools/optimize": "^1.3.1",
+    "@luckycatfactory/esbuild-graphql-loader": "^3.7.0",
     "esbuild": "^0.15.3",
     "miniflare": "^2.6.0",
     "wrangler": "^2.0.25"

--- a/src/@types/graphql.d.ts
+++ b/src/@types/graphql.d.ts
@@ -1,0 +1,6 @@
+declare module '*.graphql' {
+  import { DocumentNode } from 'graphql';
+  const Schema: DocumentNode;
+
+  export = Schema;
+}

--- a/src/handlers/apollo.ts
+++ b/src/handlers/apollo.ts
@@ -1,7 +1,7 @@
 import { ApolloServer } from "apollo-server-cloudflare";
 import { graphqlCloudflare } from "apollo-server-cloudflare/src/cloudflareApollo";
 
-import typeDefs from '../schema';
+import typeDefs from '../schema.graphql';
 import resolvers from '../resolvers';
 import kvCache from '../kv-cache';
 

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1,0 +1,3 @@
+type Query {
+  example: String!
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,9 +1,0 @@
-import { gql } from "apollo-server-cloudflare";
-
-const schema = gql`
-  type Query {
-    example: String!
-  }
-`;
-
-export default schema;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,14 @@
 {
-  "include": ["**/*.ts", "worker.build.js"],
+  "include": ["**/*.ts"],
   "compilerOptions": {
     "target": "ES2019",
     "module": "CommonJS",
     "lib": ["ES2019"],
     "strict": true,
     "allowJs": true,
+    "allowSyntheticDefaultImports": true,
     "types": ["@cloudflare/workers-types"],
+    "typeRoots": ["node_modules/@types", "src/@types"],
     "baseUrl": ".",
     "paths": {
       "~/*": ["./src/*"]

--- a/worker.build.js
+++ b/worker.build.js
@@ -1,6 +1,8 @@
 const { build } = require('esbuild');
 const { NodeModulesPolyfillPlugin } = require('@esbuild-plugins/node-modules-polyfill');
 const { NodeGlobalsPolyfillPlugin } = require('@esbuild-plugins/node-globals-polyfill');
+const { default: GraphQLLoaderPlugin } = require('@luckycatfactory/esbuild-graphql-loader');
+const { optimizeDocumentNode } = require('@graphql-tools/optimize');
 
 const isProd = process.env.NODE_ENV === 'production';
 
@@ -13,6 +15,11 @@ build({
   plugins: [
     NodeModulesPolyfillPlugin(),
     NodeGlobalsPolyfillPlugin({ buffer: true }),
+    GraphQLLoaderPlugin({
+      mapDocumentNode: (documentNode) => {
+        return optimizeDocumentNode(documentNode);
+      }
+    }),
   ],
 })
 .catch(() => process.exit(1));


### PR DESCRIPTION
- Move GraphQL schema to separated file `schema.graphql`
- Support importing `*.graphql` in Typescript