### PR TITLE
feat: integrate graphql-codegen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode
 
 build
+src/@types/schema.generated.ts
 node_modules
 .env
 

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,0 +1,16 @@
+schema: "./src/schema.graphql"
+
+generates:
+  ./src/@types/schema.generated.ts:
+    plugins:
+      - typescript
+      - typescript-resolvers
+    config:
+      enumsAsConst: true
+      namingConvention:
+        enumValues: keep
+      # enumValues:
+      #   VoteStatus:
+      #     UP: 1
+      #     DOWN: -1
+      #     NONE: 0

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "miniflare-typescript-esbuild",
   "main": "./build/index.js",
   "scripts": {
+    "generate": "graphql-codegen --config codegen.yml",
     "build": "NODE_ENV=production node worker.build.js",
     "dev": "miniflare --watch --debug --host 0.0.0.0",
     "deploy": "wrangler publish"
@@ -10,10 +11,14 @@
     "@cloudflare/workers-types": "^3.14.1",
     "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
     "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
+    "@graphql-codegen/cli": "^2.13.1",
+    "@graphql-codegen/typescript": "^2.7.3",
+    "@graphql-codegen/typescript-resolvers": "^2.7.3",
     "@graphql-tools/optimize": "^1.3.1",
     "@luckycatfactory/esbuild-graphql-loader": "^3.7.0",
     "esbuild": "^0.15.3",
     "miniflare": "^2.6.0",
+    "typescript": "^4.8.4",
     "wrangler": "^2.0.25"
   },
   "engines": {

--- a/src/@types/apollo.d.ts
+++ b/src/@types/apollo.d.ts
@@ -1,0 +1,44 @@
+export {};
+
+declare global {
+  type ApolloContext = {};
+
+  interface CorsOptions {
+    allowCredentials?: string | undefined;
+    allowHeaders?: string | undefined;
+    allowOrigin?: string | undefined;
+    allowMethods?: string | undefined;
+  }
+
+  interface GraphQLOptions {
+    // Set the path for the GraphQL server
+    baseEndpoint: string;
+
+    // Set the path for the GraphQL playground
+    // This option can be removed to disable the playground route
+    playgroundEndpoint?: string;
+
+    // When a request's path isn't matched, forward it to the origin
+    forwardUnmatchedRequestsToOrigin?: boolean,
+
+    // Enable debug mode to return script errors directly in browser
+    debug?: boolean;
+
+    // Enable CORS headers on GraphQL requests
+    // Set to `true` for defaults (see `utils/setCors`),
+    // or pass an object to configure each header
+    // cors: {
+    //   allowCredentials: 'true',
+    //   allowHeaders: 'Content-type',
+    //   allowOrigin: '*',
+    //   allowMethods: 'GET, POST, PUT',
+    // },
+    cors?: CorsOptions;
+
+    // Enable KV caching for external REST data source requests
+    // Note that you'll need to add a KV namespace called
+    // WORKERS_GRAPHQL_CACHE in your wrangler.toml file for this to
+    // work! See the project README for more information.
+    kvCache?: boolean;
+  }
+}

--- a/src/handlers/apollo.ts
+++ b/src/handlers/apollo.ts
@@ -5,45 +5,6 @@ import typeDefs from '../schema.graphql';
 import resolvers from '../resolvers';
 import kvCache from '../kv-cache';
 
-export interface CorsOptions {
-  allowCredentials?: string | undefined;
-  allowHeaders?: string | undefined;
-  allowOrigin?: string | undefined;
-  allowMethods?: string | undefined;
-}
-
-export interface GraphQLOptions {
-  // Set the path for the GraphQL server
-  baseEndpoint: string;
-
-  // Set the path for the GraphQL playground
-  // This option can be removed to disable the playground route
-  playgroundEndpoint?: string;
-
-  // When a request's path isn't matched, forward it to the origin
-  forwardUnmatchedRequestsToOrigin?: boolean,
-
-  // Enable debug mode to return script errors directly in browser
-  debug?: boolean;
-
-  // Enable CORS headers on GraphQL requests
-  // Set to `true` for defaults (see `utils/setCors`),
-  // or pass an object to configure each header
-  // cors: {
-  //   allowCredentials: 'true',
-  //   allowHeaders: 'Content-type',
-  //   allowOrigin: '*',
-  //   allowMethods: 'GET, POST, PUT',
-  // },
-  cors?: CorsOptions;
-
-  // Enable KV caching for external REST data source requests
-  // Note that you'll need to add a KV namespace called
-  // WORKERS_GRAPHQL_CACHE in your wrangler.toml file for this to
-  // work! See the project README for more information.
-  kvCache?: boolean;
-}
-
 export const apolloHandler = async (request: Request, options: GraphQLOptions) => {
   const server = new ApolloServer({
     typeDefs,

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,4 +1,6 @@
-const resolvers = {
+import { Resolvers } from "./@types/schema.generated";
+
+const resolvers: Resolvers<ApolloContext> = {
   Query: {
     example: () => {
       return 'Hello world!';

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,7 +9,7 @@ kv_namespaces = [
 compatibility_date = "2022-09-29"
 
 [build]
-command = "npm run build"
+command = "npm run generate && npm run build"
 
 [vars]
 GRAPHQL_BASE_ENDPOINT = "/"


### PR DESCRIPTION
[Integrate graphql-codegen](https://www.the-guild.dev/graphql/codegen/docs/getting-started)

- Using graphql-codegen to generate typescript types from `schema.graphql`
- Add `npm run generate` to run graphql-codegen cli
- Generated file: `src/@types/schema.generated.ts`

Usages:

```typescript
// resolvers.ts

import { Resolvers } from "./@types/schema.generated";

const resolvers: Resolvers<ApolloContext> = {
  Query: {
    example: () => {
      return 'Hello world!';
    }
  }
}

export default resolvers;
```