### PR TITLE
fix: kv cache does not work

### DIFF
--- a/src/datasources/pokemon-api.ts
+++ b/src/datasources/pokemon-api.ts
@@ -7,7 +7,11 @@ class PokemonAPI extends RESTDataSource {
   }
 
   public getPokemon(id: string) {
-    return this.get(`pokemon/${id}`)
+    return this.get(`pokemon/${id}`, undefined, {
+      cacheOptions: {
+        ttl: 60,
+      },
+    })
   }
 }
 

--- a/src/handlers/apollo.ts
+++ b/src/handlers/apollo.ts
@@ -3,8 +3,10 @@ import { graphqlCloudflare } from "apollo-server-cloudflare/src/cloudflareApollo
 
 import typeDefs from '../schema.graphql';
 import resolvers from '../resolvers';
-import kvCache from '../kv-cache';
+import KVCache from '../kv-cache';
 import PokemonAPI from "~/datasources/pokemon-api";
+
+const kvCache = { cache: new KVCache() };
 
 const dataSources = (): ApolloDataSources => ({
   pokemonAPI: new PokemonAPI(),

--- a/src/kv-cache.ts
+++ b/src/kv-cache.ts
@@ -11,7 +11,7 @@ export default class KVCache implements KeyValueCache {
     const opts: KVNamespacePutOptions = {};
 
     if (options) {
-      opts.expirationTtl = options.ttl || undefined;
+      opts.expirationTtl = Number(options.ttl) < 60 ? Number(options.ttl) : undefined;
     }
 
     return GRAPHQL_CACHE.put(key, value, opts);


### PR DESCRIPTION
- Fix wrong configuration for cache
- Apollo RESTDatasource sets cache TTL = 10 by default.
- Min TTL of KV must greater than 60. Therefore, if TTL < 60, set ttl = undefined to using no-cache.